### PR TITLE
Fix the formula for predicting herdimmunity

### DIFF
--- a/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/CSVPullerAndParser.scala
+++ b/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/CSVPullerAndParser.scala
@@ -1,10 +1,12 @@
 package com.revature.scalawags.project3.herdimmunity
 
-import com.github.nscala_time.time.Imports._
 import java.io.PrintWriter
+
 import scala.collection.mutable.ArrayBuffer
 import scala.language.postfixOps
 import sys.process._
+
+import com.github.nscala_time.time.Imports._
 
 object CSVPullerAndParser {
 

--- a/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/HerdImmunity.scala
+++ b/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/HerdImmunity.scala
@@ -9,17 +9,14 @@ object HerdImmunity {
   /** Returns the number of days until reaching herd immunity, based on total 
     * population, population already vaccinated, vaccination administration rate, 
     * and target vaccinated percentage for the pandemic.
+    * 
+    * @return `None` if `data.newVaccinationsSmoothed == 0`
     */
-  def daysRemaining(
-    totalPopulation: Int, 
-    vaccinatedPopulation: Int, 
-    dailyAdministered: Int,
-    herdImmunityPercent: Double = .75
-  ): Int = {
-    val targetPop = totalPopulation * herdImmunityPercent
-    val effectiveDaily = dailyAdministered * VaccinationEfficacy
+  def daysRemaining(data: AnalysisData, herdImmunityPercent: Double = .75): Option[Int] = {
+    val remaining = (data.population * herdImmunityPercent) - data.peopleFullyVaccinated
+    val effectiveDaily = data.newVaccinationsSmoothed * VaccinationEfficacy
     
-    math.ceil(targetPop / effectiveDaily).toInt
+    Option(math.ceil(remaining / effectiveDaily).toInt)
   }
 
   /** Returns the date achieving herd immunity based on the number of days from

--- a/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/Main.scala
+++ b/herdimmunity/src/main/scala/com/revature/scalawags/project3/herdimmunity/Main.scala
@@ -1,42 +1,50 @@
 package com.revature.scalawags.project3.herdimmunity
 
+import java.io.{BufferedWriter, IOException, FileWriter, PrintWriter}
+
+import scala.language.postfixOps
+import sys.process._
+
+import com.github.nscala_time.time.Imports._
+
 import com.revature.scalawags.project3.herdimmunity.CSVPullerAndParser._
 import com.revature.scalawags.project3.herdimmunity.HerdImmunity._
-import java.io.PrintWriter
-import java.io.BufferedWriter
-import sys.process._
-import scala.language.postfixOps
-import com.github.nscala_time.time.Imports._
-import java.io.FileWriter
-import java.io.IOException
-
 
 object Main {
-    
-    def printResults(analysis: AnalysisData, date: String){
-        try{ 
-            val fileName = "rollingResults.txt"
-            val fileWriter = new FileWriter(s"output/$fileName",true)
-            val writer = new PrintWriter(fileWriter)
-            val finalResults = s"As of ${DateTime.now} (People Fully Vaccinated: ${analysis.peopleFullyVaccinated}, Date Of HerdImmunity: $date)"
-            writer.println(finalResults)
-            writer.close()
-        }catch {
-            case e: IOException => e.printStackTrace()
-        }
+  /** Writes vaccine data and herd immunity date to local file for syncing with 
+    * Amazon S3 bucket.
+    */
+  def printResults(analysis: AnalysisData, date: String) {
+    try { 
+      val fileName = "rollingResults.txt"
+      val fileWriter = new FileWriter(s"output/$fileName",true)
+      val writer = new PrintWriter(fileWriter)
+      val finalResults = s"As of ${DateTime.now} (People Fully Vaccinated: ${analysis.peopleFullyVaccinated}, Date Of HerdImmunity: $date)"
+      writer.println(finalResults)
+      writer.close()
+    } catch {
+      case e: IOException => e.printStackTrace()
     }
+  }
     
-    
-    def main(args: Array[String]){
-        pullCDCCSV()
-        val analysis = parseCDCCSV()
-        val days = daysRemaining(analysis.population,analysis.peopleFullyVaccinated,analysis.newVaccinationsSmoothed)
-        val dateString = prettyDate(exactDate(days))
-        printResults(analysis,dateString)
-        "aws s3 sync ./output s3://covid-analysis-p3/datawarehouse/herdimmunity/" !!
-        
+  /** Pulls and parses data from Our World in Data's COVID-19 dataset, calculates
+    * the expected date the United States will achieve herd immunity, and appends
+    * the output to an object in Amazon S3.
+    */
+  def main(args: Array[String]) {
+    pullCDCCSV()
+    val analysis = parseCDCCSV()
+    val daysOption = daysRemaining(analysis)
+    val days = daysOption match {
+      case Some(v) => v
+      case None =>
+        println("Daily Vaccinations is 0, meaning herd immunity can't be achieved." +
+          "Aborting program.")
+        sys.exit()
     }
-
-
-
+    val dateString = prettyDate(exactDate(days))
+    println(dateString)
+    // printResults(analysis,dateString)
+    // "aws s3 sync ./output s3://covid-analysis-p3/datawarehouse/herdimmunity/" !!      
+  }
 }

--- a/herdimmunity/src/test/scala/com/revature/scalawags/project3/herdimmunity/HerdImmunityTest.scala
+++ b/herdimmunity/src/test/scala/com/revature/scalawags/project3/herdimmunity/HerdImmunityTest.scala
@@ -5,21 +5,20 @@ import org.scalatest.flatspec.AnyFlatSpec
 
 class HerdImmunityTest extends AnyFlatSpec {
 
-  val dataDate = "2021-02-01".toDateTime
-  val totalPopulation = 10000
-  val vaccinatedPopulation = 2000
-  val dailyAdministered = 40
+  val data = AnalysisData(
+    date = "2021-02-01".toDateTime,
+    peopleVaccinated = 6000,
+    peopleFullyVaccinated = 2000,
+    newVaccinationsSmoothed = 40,
+    population = 10000
+  )
 
   "Days Remaining" should "return 190" in {
-    assert(HerdImmunity.daysRemaining(
-      totalPopulation,
-      vaccinatedPopulation,
-      dailyAdministered
-    ) == 190)
+    assert(HerdImmunity.daysRemaining(data).getOrElse(0) == 190)
   }
 
   "Exact Date" should "return August 10, 2021 (as DateTime object)" in {
-    assert(HerdImmunity.exactDate(190, dataDate) == "2021-8-10".toDateTime)
+    assert(HerdImmunity.exactDate(190, data.date) == "2021-8-10".toDateTime)
   }
 
   "Pretty Date" should "return 'Tuesday, August 10, 2021'" in {


### PR DESCRIPTION
- I forgot to take people already vaccinated into account (oops!), so that's fixed now.
- I noticed that the `daysRemaining` calculation could potentially try to divide by zero, so the method returns an `Option[Int]` instead of just an `Int` now.
- I changed `daysRemaining` to take an `AnalysisData` object as a parameter instead of the individual members of that object.
- While I was updating it to account for the new `Option` result from `daysRemaining`, I brought `Main.scala`'s style in line with Scala Standards.